### PR TITLE
chore: add ability to override OS_ARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=pmuir
 NAME=rhoas
 BINARY=terraform-provider-rhoas
-VERSION=0.1
-OS_ARCH=darwin_amd64
+VERSION ?= 0.1
+OS_ARCH ?= darwin_amd64
 
 default: install
 


### PR DESCRIPTION
As a Linux user, I needed to to be able to change the `OS_ARCH` value when running `make`.