### PR TITLE
chore: add link to repository

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -18,3 +18,7 @@ The RHOAS terraform provider includes resources to interact with Red Hat OpenShi
 {{tffile "examples/resources/rhoas_kafka/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Source code
+
+https://github.com/pmuir/terraform-provider-rhoas


### PR DESCRIPTION
Adding link to repository as there is no reference to Github on terraform portal 